### PR TITLE
Allow all of Sequelize options in `config.sequelize`

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -13,7 +13,7 @@ Sequelize.prototype.log = function() {
 };
 
 module.exports = app => {
-  const config = Object.assign(app.config.sequelize, {
+  const defaultConfig = {
     logging: app.logger,
     host: 'localhost',
     port: 3306,
@@ -22,7 +22,8 @@ module.exports = app => {
     define: {
       freezeTableName: false,
     },
-  });
+  };
+  const config = Object.assign(defaultConfig, app.config.sequelize);
 
   app.Sequelize = Sequelize;
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const assert = require('assert');
 const path = require('path');
 const Sequelize = require('sequelize');
 const MODELS = Symbol('loadedModels');
@@ -16,30 +15,18 @@ Sequelize.prototype.log = function() {
 module.exports = app => {
   const config = Object.assign(app.config.sequelize, {
     logging: app.logger,
+    host: 'localhost',
+    port: 3306,
+    username: 'root',
+    benchmark: true,
+    define: {
+      freezeTableName: false,
+    },
   });
 
   app.Sequelize = Sequelize;
 
-  assert(config.database, 'config.database is required');
-  assert(config.username, 'config.username is required');
-  assert(config.host, 'config.host is required');
-  assert(config.port, 'config.port is required');
-
-  const sequelize = new Sequelize(
-    config.database,
-    config.username,
-    config.password,
-    {
-      host: config.host,
-      port: config.port,
-      dialect: config.dialect,
-      logging: config.logging,
-      benchmark: true,
-      define: {
-        freezeTableName: false,
-      },
-    }
-  );
+  const sequelize = new Sequelize(config.database, config.username, config.password, config);
 
   // app.sequelize
   Object.defineProperty(app, 'model', {

--- a/test/fixtures/apps/model-app/config/config.js
+++ b/test/fixtures/apps/model-app/config/config.js
@@ -7,4 +7,11 @@ exports.sequelize = {
   password: '',
   database: 'test',
   dialect: 'mysql',
+  pool: {
+    max: 5,
+    min: 0,
+    idle: 10000,
+  },
+  storage: 'db/test-foo.sqlite',
+  timezone: '+08:01',
 };

--- a/test/fixtures/apps/model-app/config/config.js
+++ b/test/fixtures/apps/model-app/config/config.js
@@ -2,7 +2,7 @@
 
 exports.sequelize = {
   port: '3306',
-  host: 'localhost',
+  host: '127.0.0.1',
   username: 'root',
   password: '',
   database: 'test',

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -37,6 +37,32 @@ describe('test/plugin.test.js', () => {
     });
   });
 
+  describe('Database options', () => {
+    let config;
+
+    before(() => {
+      config = app.model.options;
+    });
+
+    it('should work with default config', function* () {
+      assert(config.define.freezeTableName === false);
+      assert(config.host === 'localhost');
+      assert(config.port === 3306);
+      assert(config.username === 'root');
+      assert(config.password === '');
+      assert(config.logging !== false);
+      assert(config.benchmark === true);
+    });
+
+    it('should work with fixture configs', function* () {
+      assert(config.dialect === 'mysql');
+      assert(config.host === 'localhost');
+      assert(config.pool.idle === 10000);
+      assert(config.timezone === '+08:01');
+      assert(config.storage === 'db/test-foo.sqlite');
+    });
+  });
+
   describe('Test model', () => {
     it('User.test method work', function* () {
       yield app.model.User.test();

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -46,8 +46,7 @@ describe('test/plugin.test.js', () => {
 
     it('should work with default config', function* () {
       assert(config.define.freezeTableName === false);
-      assert(config.host === 'localhost');
-      assert(config.port === 3306);
+      assert(config.port === '3306');
       assert(config.username === 'root');
       assert(config.password === '');
       assert(config.logging !== false);
@@ -56,7 +55,7 @@ describe('test/plugin.test.js', () => {
 
     it('should work with fixture configs', function* () {
       assert(config.dialect === 'mysql');
-      assert(config.host === 'localhost');
+      assert(config.host === '127.0.0.1');
       assert(config.pool.idle === 10000);
       assert(config.timezone === '+08:01');
       assert(config.storage === 'db/test-foo.sqlite');


### PR DESCRIPTION
http://docs.sequelizejs.com/en/v3/api/sequelize/#new-sequelizedatabase-usernamenull-passwordnull-options

Issue from: eggjs/egg#341

for example:

```js
exports.sequelize = {
  port: '3306',
  host: 'localhost',
  username: 'root',
  password: '',
  database: 'test',
  dialect: 'mysql',
  pool: {
    max: 5,
    min: 0,
    idle: 10000,
  },
  storage: 'db/test-foo.sqlite',
  timezone: '+08:01',
};
```

- Do not assert config.host, password, port config, let them has default value.
- Do not assert config.database, because SQLite case is not needs it.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
