### PR TITLE
Ignore non Sequelize file in app/model path on Model loader.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -52,15 +52,16 @@ function loadModel(app) {
   });
 
   for (const name of Object.keys(app[MODELS])) {
-    app.model[name] = app[MODELS][name];
-  }
-
-  for (const name of Object.keys(app.model)) {
-    const instance = app.model[name];
+    const instance = app[MODELS][name];
     // only this Sequelize Model class
     if (!(instance instanceof app.Sequelize.Model)) {
       continue;
     }
+    app.model[name] = instance;
+  }
+
+  for (const name of Object.keys(app.model)) {
+    const instance = app.model[name];
 
     if ('associate' in instance) {
       instance.associate();

--- a/test/fixtures/apps/model-app/app/model/other.js
+++ b/test/fixtures/apps/model-app/app/model/other.js
@@ -1,0 +1,4 @@
+'use strict';
+
+module.exports = {
+};

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -30,6 +30,13 @@ describe('test/plugin.test.js', () => {
       assert.ok(ctx.model.Person);
     });
 
+    it('model not load non Sequelize files', function* () {
+      assert(!('Other' in app.model));
+
+      const ctx = app.mockContext();
+      assert(!('Other' in ctx.model));
+    });
+
     it('has right tableName', () => {
       assert(app.model.Person.tableName === 'people');
       assert(app.model.User.tableName === 'users');


### PR DESCRIPTION
载入 app/model/*.js 的时候，忽略非 Sequelize 的文件。

修正 eggjs/egg#805 场景错误载入非 Sequelize 文件的问题，甚至也会载入其他不应该载入的。