### PR TITLE
fix(migration): always use production config

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -18,8 +18,8 @@ const unittestConfig = requireConfig('unittest');
 const prodConfig = requireConfig('prod');
 
 module.exports = {
-  development: Object.assign(defaultConfig, localConfig),
-  test: Object.assign(defaultConfig, unittestConfig),
-  production: Object.assign(defaultConfig, prodConfig),
+  development: Object.assign({}, defaultConfig, localConfig),
+  test: Object.assign({}, defaultConfig, unittestConfig),
+  production: Object.assign({}, defaultConfig, prodConfig),
 };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
###### Environment

Node: v6.9.0
egg-sequelize: 2.1.3

###### Description

When use `npm run migrate:up` always error, because the config file is covered by the `production` environment. See [#895](https://github.com/eggjs/egg/issues/895)