### PR TITLE
feat: Upgrade Sequelize V4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # egg-sequelize
 
-Sequelize plugin in egg
+[Sequelize](http://sequelizejs.com) plugin for Egg.js.
+
+> NOTE: This plugin just for integrate Sequelize into Egg.js, more documention please visit http://sequelizejs.com.
 
 [![NPM version][npm-image]][npm-url]
 [![build status][travis-image]][travis-url]
@@ -22,16 +24,14 @@ Sequelize plugin in egg
 [download-image]: https://img.shields.io/npm/dm/egg-sequelize.svg?style=flat-square
 [download-url]: https://npmjs.org/package/egg-sequelize
 
-Egg's sequelize plugin.
-
 ## Install
 
 ```bash
 $ npm i --save egg-sequelize
+$ npm install --save mysql2 # For both mysql and mariadb dialects
 
-# And one of the following:
-$ npm install --save pg pg-hstore
-$ npm install --save mysql # For both mysql and mariadb dialects
+# Or use other database backend.
+$ npm install --save pg pg-hstore # PostgreSQL
 $ npm install --save tedious # MSSQL
 ```
 
@@ -39,6 +39,7 @@ $ npm install --save tedious # MSSQL
 ## Usage & configuration
 
 - `config.default.js`
+
 ```js
 exports.sequelize = {
   dialect: 'mysql', // support: mysql, mariadb, postgres, mssql
@@ -49,7 +50,9 @@ exports.sequelize = {
   password: '',
 };
 ```
+
 - `config/plugin.js`
+
 ``` js
 exports.sequelize = {
   enable: true,
@@ -97,20 +100,25 @@ Define a model first.
 module.exports = app => {
   const { STRING, INTEGER, DATE } = app.Sequelize;
 
-  return app.model.define('user', {
+  const User = app.model.define('user', {
     login: STRING,
     name: STRING(30),
     password: STRING(32),
     age: INTEGER,
+    last_sign_in_at: DATE,
     created_at: DATE,
     updated_at: DATE,
-  }, {
-    classMethods: {
-      * findByLogin(login) {
-        return yield this.findOne({ login: login });
-      },
-    },
   });
+
+  User.findByLogin = function* (login) {
+    return yield this.findOne({ login: login });
+  }
+
+  User.prototype.logSignin = function* () {
+    yield this.update({ last_sign_in_at: new Date() });
+  }
+
+  return User;
 };
 
 ```
@@ -125,13 +133,17 @@ module.exports = app => {
       const users = yield this.ctx.model.User.findAll();
       this.ctx.body = users;
     }
+
+    * show() {
+      const user = yield this.ctx.model.User.findByLogin(this.ctx.params.login);
+      yield user.logSignin();
+      this.ctx.body = user;
+    }
   }
 }
 ```
 
 ### Full example
-
-
 
 ```js
 // app/model/post.js
@@ -139,18 +151,18 @@ module.exports = app => {
 module.exports = app => {
   const { STRING, INTEGER, DATE } = app.Sequelize;
 
-  return app.model.define('Post', {
+  const Post = app.model.define('Post', {
     name: STRING(30),
     user_id: INTEGER,
     created_at: DATE,
     updated_at: DATE,
-  }, {
-    classMethods: {
-      associate() {
-        app.model.Post.belongsTo(app.model.User, { as: 'user' });
-      }
-    }
   });
+
+  Post.associate = function() {
+    app.model.Post.belongsTo(app.model.User, { as: 'user' });
+  }
+
+  return Post;
 };
 ```
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -54,9 +54,15 @@ function loadModel(app) {
 
   for (const name of Object.keys(app[MODELS])) {
     const klass = app[MODELS][name];
+
     // only this Sequelize Model class
     if ('sequelize' in klass) {
       app.model[name] = klass;
+
+      if ('classMethods' in klass.options || 'instanceMethods' in klass.options) {
+        app.logger.error(`${name} model has classMethods/instanceMethods, but it was removed supports in Sequelize V4.\
+see: http://docs.sequelizejs.com/manual/tutorial/models-definition.html#expansion-of-models`);
+      }
     }
 
     if ('associate' in klass) {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -53,19 +53,14 @@ function loadModel(app) {
   });
 
   for (const name of Object.keys(app[MODELS])) {
-    const instance = app[MODELS][name];
+    const klass = app[MODELS][name];
     // only this Sequelize Model class
-    if (!(instance instanceof app.Sequelize.Model)) {
-      continue;
+    if ('sequelize' in klass) {
+      app.model[name] = klass;
     }
-    app.model[name] = instance;
-  }
 
-  for (const name of Object.keys(app.model)) {
-    const instance = app.model[name];
-
-    if ('associate' in instance) {
-      instance.associate();
+    if ('associate' in klass) {
+      klass.associate();
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,21 +14,21 @@
   ],
   "dependencies": {
     "chalk": "^1.1.3",
-    "sequelize": "^3.30.1",
+    "sequelize": "^4.1.0",
     "sequelize-cli": "^2.7.0"
   },
   "devDependencies": {
-    "autod": "^2.7.1",
-    "egg": "^0.12.0",
-    "egg-bin": "^2.0.2",
-    "egg-mock": "^2.3.1",
+    "autod": "^2.8.0",
+    "egg": "^1.4.0",
+    "egg-bin": "^3.4.2",
+    "egg-mock": "^3.7.2",
+    "eslint": "^4.0.0",
+    "eslint-config-egg": "^4.2.1",
+    "mysql2": "^1.3.4",
     "power-assert": "^1.4.2",
-    "eslint": "^3.15.0",
-    "eslint-config-egg": "^3.2.0",
-    "mysql": "^2.12.0",
     "should": "^11.2.0",
     "supertest": "^3.0.0",
-    "webstorm-disable-index": "^1.1.2"
+    "webstorm-disable-index": "^1.2.0"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/test/fixtures/apps/model-app/app/model/Person.js
+++ b/test/fixtures/apps/model-app/app/model/Person.js
@@ -2,7 +2,9 @@
 
 module.exports = app => {
   const { STRING } = app.Sequelize;
-  return app.model.define('person', {
+  const Person = app.model.define('person', {
     name: STRING(30),
   });
+
+  return Person;
 };

--- a/test/fixtures/apps/model-app/app/model/monkey.js
+++ b/test/fixtures/apps/model-app/app/model/monkey.js
@@ -12,6 +12,9 @@ module.exports = app => {
     updated_at: DATE,
   }, {
     tableName: 'the_monkeys',
+
+    classMethods: {
+    },
   });
 
   Monkey.findUser = function* () {

--- a/test/fixtures/apps/model-app/app/model/monkey.js
+++ b/test/fixtures/apps/model-app/app/model/monkey.js
@@ -2,7 +2,7 @@
 
 module.exports = app => {
   const { STRING, INTEGER, DATE } = app.Sequelize;
-  return app.model.define('monkey', {
+  const Monkey = app.model.define('monkey', {
     name: {
       type: STRING,
       allowNull: false,
@@ -12,10 +12,11 @@ module.exports = app => {
     updated_at: DATE,
   }, {
     tableName: 'the_monkeys',
-    classMethods: {
-      * findUser() {
-        return yield app.model.User.find({ id: 1 });
-      },
-    },
   });
+
+  Monkey.findUser = function* () {
+    return yield app.model.User.find({ id: 1 });
+  };
+
+  return Monkey;
 };

--- a/test/fixtures/apps/model-app/app/model/monkey.js
+++ b/test/fixtures/apps/model-app/app/model/monkey.js
@@ -15,6 +15,9 @@ module.exports = app => {
 
     classMethods: {
     },
+
+    instanceMethods: {
+    },
   });
 
   Monkey.findUser = function* () {

--- a/test/fixtures/apps/model-app/app/model/user.js
+++ b/test/fixtures/apps/model-app/app/model/user.js
@@ -4,23 +4,23 @@ const assert = require('assert');
 
 module.exports = app => {
   const { STRING, INTEGER } = app.Sequelize;
-  return app.model.define('user', {
+  const User = app.model.define('user', {
     name: STRING(30),
     age: INTEGER,
-  }, {
-    classMethods: {
-      associate() {
-        assert.ok(app.model.User);
-      },
-
-      * test() {
-        assert(app.config);
-        assert(app.model.User === this);
-        const monkey = yield app.model.Monkey.create({ name: 'The Monkey' });
-        assert(monkey.id);
-        assert(monkey.isNewRecord === false);
-        assert(monkey.name === 'The Monkey');
-      },
-    },
   });
+
+  User.associate = function() {
+    assert.ok(app.model.User);
+  };
+
+  User.test = function* () {
+    assert(app.config);
+    assert(app.model.User === this);
+    const monkey = yield app.model.Monkey.create({ name: 'The Monkey' });
+    assert(monkey.id);
+    assert(monkey.isNewRecord === false);
+    assert(monkey.name === 'The Monkey');
+  };
+
+  return User;
 };

--- a/test/fixtures/apps/model-app/config/config.js
+++ b/test/fixtures/apps/model-app/config/config.js
@@ -15,3 +15,5 @@ exports.sequelize = {
   storage: 'db/test-foo.sqlite',
   timezone: '+08:01',
 };
+
+exports.keys = '0jN4Fw7ZBjo4xtrLklDg4g==';

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -89,10 +89,10 @@ describe('test/plugin.test.js', () => {
       app.mockCsrf();
 
       yield request(app.callback())
-      .post('/users')
-      .send({
-        name: 'popomore',
-      });
+        .post('/users')
+        .send({
+          name: 'popomore',
+        });
       const user = yield app.model.User.findOne({
         where: { name: 'popomore' },
       });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -13,7 +13,7 @@ describe('test/plugin.test.js', () => {
     });
     return app.ready();
   });
-  before(() => app.model.sync({ force: true }));
+  before(() => app.model.sync({ alter: true }));
 
   after(mm.restore);
 
@@ -24,6 +24,7 @@ describe('test/plugin.test.js', () => {
 
     it('ctx model property getter', () => {
       const ctx = app.mockContext();
+      console.log(ctx.model.User);
       assert.ok(ctx.model);
       assert.ok(ctx.model.User);
       assert.ok(ctx.model.Monkey);


### PR DESCRIPTION
ref: eggjs/egg#1026

### TODO:

- CHANGELOG 需要说明 Break Changes.
- 需要发布大版本

### Break Changes

以我的观察来看

- NPM 关于 MySQL 的依赖要从 `mysql` 改为 [mysql2](https://www.npmjs.com/package/mysql2)
- 查询的 `order` 参数不能用字符串了，详见 [Ordering](http://docs.sequelizejs.com/manual/tutorial/querying.html#ordering)

```js
app.model.User.findAll({
  order: [
    ["id", "desc"]
  ]
});
```

- Model define 里面，不能用 `classMethods` 和 `instanceMethods` 方法了，详见 [Model definition](http://docs.sequelizejs.com/manual/tutorial/models-definition.html)

```js
module.exports = app => {
  const { STRING, INTEGER, DATE } = app.Sequelize;
  const User = app.model.define('user', {
    login: STRING(40),
    name: STRING,
    last_signin_ip: STRING,
    last_signin_at: DATE,
  });

  User.findByLogin = function* (login) {
    return yield this.findOne({
      where: { login: login },
    });
  };

  User.prototype.updateLastSignIn(ip) {
    yield this.update({
      last_signin_ip: ip,
      last_signin_at: new Date();
    });
  }

  return User;
};
```

更多内容请阅读 [Upgrade to v4](http://docs.sequelizejs.com/manual/tutorial/upgrade-to-v4.html)