### PR TITLE
refactor: rewrite cli script with plain js instead of Shell to support multi-platform.

### DIFF
--- a/bin/egg-sequelize
+++ b/bin/egg-sequelize
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-EGG_SEQUELIZE_ROOT=./node_modules/egg-sequelize
-SEQUELIZE_ROOT=$EGG_SEQUELIZE_ROOT/node_modules/sequelize-cli
-if [ ! -d "$SEQUELIZE_ROOT" ]; then
-    SEQUELIZE_ROOT=./node_modules/sequelize-cli
-fi
-$SEQUELIZE_ROOT/bin/sequelize --optionsPath $EGG_SEQUELIZE_ROOT/lib/sequelizerc.js $@

--- a/bin/egg-sequelize.js
+++ b/bin/egg-sequelize.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict';
 
 const path = require('path');

--- a/bin/egg-sequelize.js
+++ b/bin/egg-sequelize.js
@@ -1,0 +1,19 @@
+const path = require('path');
+const fs = require('fs');
+const child_process = require('child_process');
+
+const eggSequelizeRoot = __dirname;
+let sequelizeRoot = path.resolve(eggSequelizeRoot, './node_modules/sequelize-cli');
+
+if (!fs.existsSync(sequelizeRoot)) {
+  sequelizeRoot = './node_modules/sequelize-cli';
+}
+
+const sequelizeBin = path.resolve(sequelizeRoot, './bin/sequelize');
+const args = [
+  sequelizeBin,
+  '--optionsPath',
+  path.resolve(eggSequelizeRoot, '../lib/sequelizerc.js'),
+].concat(process.argv.slice(2));
+
+child_process.spawn(process.argv[0], args, { stdio: 'inherit' });

--- a/bin/egg-sequelize.js
+++ b/bin/egg-sequelize.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const fs = require('fs');
 const child_process = require('child_process');

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "autod": "autod"
   },
   "bin": {
-    "egg-sequelize": "bin/egg-sequelize"
+    "egg-sequelize": "bin/egg-sequelize.js"
   },
   "files": [
     "app",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
In the former version, the cli doesn't work on Windows because the cli script is a Shell script and only works on *nix.
I rewrite ``./bin/egg-sequelize`` to ``./bin/egg-sequelize.js``. Using plain js to execute ``sequelize-cli``.

Manual test is complete on both Windows and *nix(Bash on Windows).
I think if necessary to test on a real Linux system.

close https://github.com/eggjs/egg/issues/1277