### PR TITLE
feature: support multiple database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - '6'
   - '7'
+  - '8'
 install:
   - npm i npminstall && npminstall
 script:
@@ -13,3 +14,5 @@ services:
   - mysql
 before_install:
   - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS test1;'
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS test2;'

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -7,4 +7,13 @@ exports.sequelize = {
   port: 3306,
   username: 'root',
   password: '',
+  modelDir: 'app/model',
+  default: {
+    dialect: 'mysql',
+    database: '',
+    host: 'localhost',
+    port: 3306,
+    username: 'root',
+    password: '',
+  },
 };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const Sequelize = require('sequelize');
-const MODELS = Symbol('loadedModels');
 const chalk = require('chalk');
 
 Sequelize.prototype.log = function() {
@@ -24,28 +23,59 @@ module.exports = app => {
       underscored: true,
     },
   };
-  const config = Object.assign(defaultConfig, app.config.sequelize);
+  const config = Object.assign({}, defaultConfig, app.config.sequelize);
 
   app.Sequelize = Sequelize;
 
-  const sequelize = new Sequelize(config.database, config.username, config.password, config);
+  if (config.clients) {
+    // app.sequelize
+    Object.defineProperty(app, 'model', {
+      value: {},
+      writable: false,
+      configurable: false,
+    });
 
-  // app.sequelize
-  Object.defineProperty(app, 'model', {
-    value: sequelize,
-    writable: false,
-    configurable: false,
-  });
+    for (const name of Object.keys(config.clients)) {
+      const clientConfig = Object.assign({}, defaultConfig, app.config.sequelize.default, app.config.sequelize.clients[name]);
 
-  loadModel(app);
+      const sequelize = new Sequelize(clientConfig.database, clientConfig.username, clientConfig.password, clientConfig);
+
+      Object.defineProperty(app.model, clientConfig.name, {
+        value: sequelize,
+        writable: false,
+        configurable: false,
+      });
+
+      loadModel(app, { instance: sequelize, modelDir: clientConfig.modelDir, name: clientConfig.name });
+    }
+  } else {
+    const sequelize = new Sequelize(config.database, config.username, config.password, config);
+    // app.sequelize
+    Object.defineProperty(app, 'model', {
+      value: sequelize,
+      writable: false,
+      configurable: false,
+    });
+    loadModel(app, { instance: sequelize, modelDir: config.modelDir, name: config.name });
+  }
 
   app.beforeStart(function* () {
-    yield app.model.authenticate();
+    if (app.config.sequelize.clients) {
+      for (const name of Object.keys(config.clients)) {
+        const dbName = app.config.sequelize.clients[name].name;
+        yield app.model[dbName].authenticate();
+      }
+    } else {
+      console.log(app.config.sequelize.name);
+      yield app.model.authenticate();
+    }
   });
 };
 
-function loadModel(app) {
-  const modelDir = path.join(app.baseDir, 'app/model');
+function loadModel(app, options) {
+  const MODELS = Symbol(`loadedModels${options.name ? ('#' + options.name) : ''}`);
+
+  const modelDir = path.join(app.baseDir, options.modelDir);
   app.loader.loadToApp(modelDir, MODELS, {
     inject: app,
     caseStyle: 'upper',
@@ -57,7 +87,7 @@ function loadModel(app) {
 
     // only this Sequelize Model class
     if ('sequelize' in klass) {
-      app.model[name] = klass;
+      options.instance[name] = klass;
 
       if ('classMethods' in klass.options || 'instanceMethods' in klass.options) {
         app.logger.error(`${name} model has classMethods/instanceMethods, but it was removed supports in Sequelize V4.\

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -40,13 +40,13 @@ module.exports = app => {
 
       const sequelize = new Sequelize(clientConfig.database, clientConfig.username, clientConfig.password, clientConfig);
 
-      Object.defineProperty(app.model, clientConfig.name, {
+      Object.defineProperty(app.model, name, {
         value: sequelize,
         writable: false,
         configurable: false,
       });
 
-      loadModel(app, { instance: sequelize, modelDir: clientConfig.modelDir, name: clientConfig.name });
+      loadModel(app, { instance: sequelize, modelDir: clientConfig.modelDir, name });
     }
   } else {
     const sequelize = new Sequelize(config.database, config.username, config.password, config);
@@ -56,14 +56,13 @@ module.exports = app => {
       writable: false,
       configurable: false,
     });
-    loadModel(app, { instance: sequelize, modelDir: config.modelDir, name: config.name });
+    loadModel(app, { instance: sequelize, modelDir: config.modelDir });
   }
 
   app.beforeStart(function* () {
     if (app.config.sequelize.clients) {
       for (const name of Object.keys(config.clients)) {
-        const dbName = app.config.sequelize.clients[name].name;
-        yield app.model[dbName].authenticate();
+        yield app.model[name].authenticate();
       }
     } else {
       console.log(app.config.sequelize.name);

--- a/test/fixtures/apps/multiple-db/app/controller/users.js
+++ b/test/fixtures/apps/multiple-db/app/controller/users.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = app => {
+  return class UsersController extends app.Controller {
+    * show() {
+      const user = yield this.ctx.model.db1.User.findById(this.ctx.params.id);
+      this.ctx.body = user;
+    }
+
+    * create() {
+      yield app.model.db1.User.create({
+        name: this.ctx.request.body.name,
+      });
+    }
+  };
+};

--- a/test/fixtures/apps/multiple-db/app/model/db1/Person.js
+++ b/test/fixtures/apps/multiple-db/app/model/db1/Person.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = app => {
+  const { STRING } = app.Sequelize;
+  const Person = app.model.db1.define('person', {
+    name: STRING(30),
+  });
+
+  return Person;
+};

--- a/test/fixtures/apps/multiple-db/app/model/db1/post.js
+++ b/test/fixtures/apps/multiple-db/app/model/db1/post.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = app => {
+  const { INTEGER, STRING } = app.Sequelize;
+  const Post = app.model.db1.define('post', {
+    user_id: INTEGER,
+    name: STRING(30),
+  });
+
+  Post.associate = function() {
+    assert.ok(app.model.db1.User);
+    assert.ok(app.model.db1.Post);
+    app.model.db1.Post.belongsTo(app.model.db1.User, { as: 'user', foreignKey: 'user_id' });
+  };
+
+  return Post;
+};

--- a/test/fixtures/apps/multiple-db/app/model/db1/user.js
+++ b/test/fixtures/apps/multiple-db/app/model/db1/user.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = app => {
+  const { STRING, INTEGER } = app.Sequelize;
+  const User = app.model.db1.define('user', {
+    name: STRING(30),
+    age: INTEGER,
+  });
+
+  User.associate = function() {
+    assert.ok(app.model.db1.User);
+    assert.ok(app.model.db1.Post);
+    app.model.db1.User.hasMany(app.model.db1.Post, { as: 'posts', foreignKey: 'user_id' });
+  };
+
+  User.test = function* () {
+    assert(app.config);
+    assert(app.model.db1.User === this);
+  };
+
+  return User;
+};

--- a/test/fixtures/apps/multiple-db/app/model/db2/Person.js
+++ b/test/fixtures/apps/multiple-db/app/model/db2/Person.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = app => {
+  const { STRING } = app.Sequelize;
+  const Person = app.model.db2.define('person', {
+    name: STRING(30),
+  });
+
+  return Person;
+};

--- a/test/fixtures/apps/multiple-db/app/model/db2/post.js
+++ b/test/fixtures/apps/multiple-db/app/model/db2/post.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = app => {
+  const { INTEGER, STRING } = app.Sequelize;
+  const Post = app.model.db2.define('post', {
+    user_id: INTEGER,
+    name: STRING(30),
+  });
+
+  Post.associate = function() {
+    assert.ok(app.model.db2.User);
+    assert.ok(app.model.db2.Post);
+    app.model.db2.Post.belongsTo(app.model.db2.User, { as: 'user', foreignKey: 'user_id' });
+  };
+
+  return Post;
+};

--- a/test/fixtures/apps/multiple-db/app/model/db2/user.js
+++ b/test/fixtures/apps/multiple-db/app/model/db2/user.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = app => {
+  const { STRING, INTEGER } = app.Sequelize;
+  const User = app.model.db2.define('user', {
+    name: STRING(30),
+    age: INTEGER,
+  });
+
+  User.associate = function() {
+    assert.ok(app.model.db2.User);
+    assert.ok(app.model.db2.Post);
+    app.model.db2.User.hasMany(app.model.db2.Post, { as: 'posts', foreignKey: 'user_id' });
+  };
+
+  User.test = function* () {
+    assert(app.config);
+    assert(app.model.db2.User === this);
+  };
+
+  return User;
+};

--- a/test/fixtures/apps/multiple-db/app/router.js
+++ b/test/fixtures/apps/multiple-db/app/router.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(app) {
+  app.resources('users', '/users', 'users');
+};

--- a/test/fixtures/apps/multiple-db/config/config.js
+++ b/test/fixtures/apps/multiple-db/config/config.js
@@ -4,12 +4,10 @@ exports.sequelize = {
   clients: {
     db1: {
       database: 'test1',
-      name: 'db1',
       modelDir: 'app/model/db1',
     },
     db2: {
       database: 'test2',
-      name: 'db2',
       modelDir: 'app/model/db2',
     },
   },

--- a/test/fixtures/apps/multiple-db/config/config.js
+++ b/test/fixtures/apps/multiple-db/config/config.js
@@ -1,0 +1,32 @@
+'use strict';
+
+exports.sequelize = {
+  clients: {
+    db1: {
+      database: 'test1',
+      name: 'db1',
+      modelDir: 'app/model/db1',
+    },
+    db2: {
+      database: 'test2',
+      name: 'db2',
+      modelDir: 'app/model/db2',
+    },
+  },
+  default: {
+    port: '3306',
+    host: '127.0.0.1',
+    username: 'root',
+    password: '',
+    dialect: 'mysql',
+    pool: {
+      max: 5,
+      min: 0,
+      idle: 10000,
+    },
+    storage: 'db/test-foo.sqlite',
+    timezone: '+08:01',
+  },
+};
+
+exports.keys = '0jN4Fw7ZBjo4xtrLklDg4g==';

--- a/test/fixtures/apps/multiple-db/package.json
+++ b/test/fixtures/apps/multiple-db/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "multiple-db"
+}

--- a/test/multiple.test.js
+++ b/test/multiple.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const assert = require('assert');
+const mm = require('egg-mock');
+const request = require('supertest');
+
+describe('test/multiple.test.js', () => {
+  let app;
+
+  before(() => {
+    app = mm.app({
+      baseDir: 'apps/multiple-db',
+    });
+    return app.ready();
+  });
+  before(() => Promise.all([
+    app.model.db1.sync({ force: true }),
+    app.model.db2.sync({ force: true }),
+  ]));
+
+  after(mm.restore);
+
+  describe('Base', () => {
+    it('sequelize init success', () => {
+      assert(app.model);
+    });
+
+    it('ctx model property getter', () => {
+      const ctx = app.mockContext();
+      assert.ok(ctx.model.db1);
+      assert.ok(ctx.model.db1.User);
+      assert.ok(ctx.model.db1.Person);
+      assert.ok(ctx.model.db2);
+      assert.ok(ctx.model.db2.User);
+      assert.ok(ctx.model.db2.Person);
+    });
+
+    it('has right tableName', () => {
+      assert(app.model.db1.Person.tableName === 'people');
+      assert(app.model.db1.User.tableName === 'users');
+      assert(app.model.db2.Person.tableName === 'people');
+      assert(app.model.db2.User.tableName === 'users');
+    });
+  });
+
+  describe('Database options', () => {
+    let config1;
+    let config2;
+
+    before(() => {
+      config1 = app.model.db1.options;
+      config2 = app.model.db2.options;
+    });
+
+    it('should work with default config', function* () {
+      assert(config1.define.freezeTableName === false);
+      assert(config1.port === '3306');
+      assert(config1.username === 'root');
+      assert(config1.password === '');
+      assert(config1.logging !== false);
+      assert(config1.benchmark === true);
+      assert(config2.define.freezeTableName === false);
+      assert(config2.port === '3306');
+      assert(config2.username === 'root');
+      assert(config2.password === '');
+      assert(config2.logging !== false);
+      assert(config2.benchmark === true);
+    });
+
+    it('should work with fixture configs', function* () {
+      assert(config1.dialect === 'mysql');
+      assert(config1.host === '127.0.0.1');
+      assert(config1.pool.idle === 10000);
+      assert(config1.timezone === '+08:01');
+      assert(config1.storage === 'db/test-foo.sqlite');
+      assert(config2.dialect === 'mysql');
+      assert(config2.host === '127.0.0.1');
+      assert(config2.pool.idle === 10000);
+      assert(config2.timezone === '+08:01');
+      assert(config2.storage === 'db/test-foo.sqlite');
+    });
+  });
+
+  describe('Test model', () => {
+    it('User.test method work', function* () {
+      yield app.model.db1.User.test();
+      yield app.model.db2.User.test();
+    });
+
+    it('should work timestramp', function* () {
+      const user = yield app.model.db1.User.create({ name: 'huacnlee' });
+      assert(user.isNewRecord === false);
+      assert(user.name === 'huacnlee');
+      assert(user.created_at !== null);
+      assert(user.updated_at !== null);
+    });
+  });
+
+  describe('Test controller', () => {
+    it('should get data from create', function* () {
+      app.mockCsrf();
+
+      yield request(app.callback())
+        .post('/users')
+        .send({
+          name: 'popomore',
+        });
+      const user = yield app.model.db1.User.findOne({
+        where: { name: 'popomore' },
+      });
+      assert.ok(user);
+      assert(user.name === 'popomore');
+      assert(user.isNewRecord === false);
+      const res = yield request(app.callback())
+        .get(`/users/${user.id}`);
+      assert(res.status === 200);
+      assert(res.body.name === 'popomore');
+    });
+  });
+
+  describe('Associate', () => {
+
+    it('ctx model associate init success', () => {
+      const ctx = app.mockContext();
+      assert.ok(ctx.model);
+      assert.ok(ctx.model.db1);
+      assert.ok(ctx.model.db1.User);
+      assert.ok(ctx.model.db1.User.prototype.hasPosts);
+      assert.ok(ctx.model.db1.Post);
+
+      assert.ok(ctx.model.db2);
+      assert.ok(ctx.model.db2.User);
+      assert.ok(ctx.model.db2.User.prototype.hasPosts);
+      assert.ok(ctx.model.db2.Post);
+    });
+
+  });
+
+});
+


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
add support for multiple database.
just config like:
```
'use strict';

exports.sequelize = {
  clients: {
    db1: {
      database: 'test1',
      modelDir: 'app/model/db1',
    },
    db2: {
      database: 'test2',
      modelDir: 'app/model/db2',
    },
  },
  default: {
    port: '3306',
    host: '127.0.0.1',
    username: 'root',
    password: '',
    dialect: 'mysql',
    pool: {
      max: 5,
      min: 0,
      idle: 10000,
    },
    storage: 'db/test-foo.sqlite',
    timezone: '+08:01',
  },
};
```
