### PR TITLE
调用 model 的 associate 的方法时传入 app 的实例

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -70,7 +70,7 @@ see: http://docs.sequelizejs.com/manual/tutorial/models-definition.html#expansio
     const klass = app[MODELS][name];
 
     if ('associate' in klass) {
-      klass.associate();
+      klass.associate(app);
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
目前插件会自动调用 Model 上的 associate 方法，但是没有给该方法提供必要的上下文，例如，Sequelize 实例。导致 associate 方法必须在 model 文件的默认导出方法中定义。而 [Sequelize V4](http://docs.sequelizejs.com/manual/tutorial/upgrade-to-v4.html) 中允许先定义一个 Model 类，再通过初始化来关联对象关系，所以可以这样定义 Model

```javascript
// app/model/post.js
import { Model } from 'sequelize'；

export class Post extends Model {
  static associate(app) {
    app.model.Post.belongsTo(app.model.User, { as: 'user' });
  }
}

export default app => {
  const { STRING, INTEGER, DATE } = app.Sequelize;

 Post.init({
    name: STRING(30),
    user_id: INTEGER,
    created_at: DATE,
    updated_at: DATE,
  });

  return Post;
};
```
