### PR TITLE
bind function [sequelize.query] to [app.Sequelize]

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -56,6 +56,19 @@ module.exports = app => {
     }
 
     const sequelize = new app.Sequelize(config.database, config.username, config.password, config);
+    /**
+     * bind function [sequelize.query] to [app.Sequelize]
+     * see sequelize.js docs [http://docs.sequelizejs.com/manual/tutorial/raw-queries.html]
+     * for example:
+     *
+     *    sequelize.query("SELECT * FROM `users`", { type: sequelize.QueryTypes.SELECT})
+            .then(users => {
+              // We don't need spread here, since only the results will be returned for select queries
+          })
+     *  so we need [app.Sequelize.query] to keep the api  matching the docs
+     *  
+     */
+    app.Sequelize.query = sequelize.query.bind(sequelize)
 
     const delegate = config.delegate.split('.');
     const len = delegate.length;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -56,17 +56,10 @@ module.exports = app => {
     }
 
     const sequelize = new app.Sequelize(config.database, config.username, config.password, config);
+    
     /**
      * bind function [sequelize.query] to [app.Sequelize]
-     * see sequelize.js docs [http://docs.sequelizejs.com/manual/tutorial/raw-queries.html]
-     * for example:
-     *
-     *    sequelize.query("SELECT * FROM `users`", { type: sequelize.QueryTypes.SELECT})
-            .then(users => {
-              // We don't need spread here, since only the results will be returned for select queries
-          })
-     *  so we need [app.Sequelize.query] to keep the api  matching the docs
-     *  
+     * see docs of sequelize.js  [http://docs.sequelizejs.com/manual/tutorial/raw-queries.html]
      */
     app.Sequelize.query = sequelize.query.bind(sequelize)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
     bind function [sequelize.query] to [app.Sequelize]
[sequelize.js docs](http://docs.sequelizejs.com/manual/tutorial/raw-queries.html)
### the example in sequelize.js:
```
 sequelize.query("SELECT * FROM `users`", { type: sequelize.QueryTypes.SELECT})
    .then(users => {
        // We don't need spread here, since only the results will be returned for select queries
 })
```

### now we can use in eggjs:

```
 this.app.Sequelize.query("SELECT * FROM `users`", { type: sequelize.QueryTypes.SELECT})
     .then(users => {
           // We don't need spread here, since only the results will be returned for select queries
 })
 ```
so we need [app.Sequelize.query] to keep the api  matching the docs