### PR TITLE
fix: default to ignore app/model/index.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ exports.sequelize = {
   password: '',
   // delegate: 'myModel', // load all models to `app[delegate]` and `ctx[delegate]`, default to `model`
   // baseDir: 'my_model', // load all files in `app/${baseDir}` as models, default to `model`
-  // exclude: 'index.js', // ignore `app/${baseDir}/index.js` when load models, support glob and array
+  exclude: 'index.js', // ignore `app/${baseDir}/index.js` when load models, support glob and array, default to `index.js`
   // more sequelize options
 };
 ```

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -7,7 +7,7 @@ exports.sequelize = {
   port: 3306,
   username: 'root',
   password: '',
-
+  exclude: 'index.js'
   // support customize your own Squelize
   // Sequelize: require('sequelize'), // v5 or v3
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
默认 exclude sequelize-cli 生成的 `app/model/index.js` 文件
https://github.com/eggjs/egg/issues/3442