### PR TITLE
feat: :sparkles: 允许配置 connection uri 来连接 mysql.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ run
 *.swp
 test/fixtures/apps/model-app/run/
 test/fixtures/apps/ts/**/*.js
+test/fixtures/apps/connection-uri/**/*.js
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ before_install:
   - mysql -e 'CREATE DATABASE IF NOT EXISTS test1;'
   - mysql -e 'CREATE DATABASE IF NOT EXISTS test2;'
   - mysql -e 'CREATE DATABASE IF NOT EXISTS test3;'
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS test4;'

--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ exports.sequelize = {
 };
 ```
 
+You can also use the `connection uri` to configure the connection:
+
+```js
+exports.sequelize = {
+  dialect: 'mysql', // support: mysql, mariadb, postgres, mssql
+  connectionUri: 'mysql://root:@127.0.0.1:3306/test',
+  // delegate: 'myModel', // load all models to `app[delegate]` and `ctx[delegate]`, default to `model`
+  // baseDir: 'my_model', // load all files in `app/${baseDir}` as models, default to `model`
+  // exclude: 'index.js', // ignore `app/${baseDir}/index.js` when load models, support glob and array
+  // more sequelize options
+};
+```
+
 egg-sequelize has a default sequelize options below
 
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ interface EggSequelizeOptions extends sequelize.Options {
   delegate?: string;
   baseDir?: string;
   exclude?: string;
+  connectionUri?: string;
 }
 
 interface DataSources {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -55,7 +55,9 @@ module.exports = app => {
       delete config.ignore;
     }
 
-    const sequelize = new app.Sequelize(config.database, config.username, config.password, config);
+    const sequelize = config.connectionUri ?
+      new app.Sequelize(config.connectionUri, config) :
+      new app.Sequelize(config.database, config.username, config.password, config);
 
     const delegate = config.delegate.split('.');
     const len = delegate.length;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "autod": "^3.0.1",
     "egg": "^2.10.0",
-    "egg-bin": "^4.8.1",
+    "egg-bin": "^4.13.1",
     "egg-mock": "^3.19.3",
     "eslint": "^5.3.0",
     "eslint-config-egg": "^7.0.0",

--- a/test/connection-uri.test.js
+++ b/test/connection-uri.test.js
@@ -27,7 +27,7 @@ describe('connection-uri', () => {
     });
     return app.ready();
   });
-  // before(() => app.model.sync({ force: true }));
+  before(() => app.model.sync({ force: true }));
 
   after(mm.restore);
 

--- a/test/connection-uri.test.js
+++ b/test/connection-uri.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const coffee = require('coffee');
+const path = require('path');
+const mm = require('egg-mock');
+const assert = require('assert');
+
+describe('connection-uri', () => {
+  let app;
+
+  before(() => {
+    console.log('compiling...');
+    return coffee
+      .fork(require.resolve('typescript/bin/tsc'), [
+        '-p',
+        path.resolve(__dirname, './fixtures/apps/connection-uri/tsconfig.json'),
+      ])
+      .debug()
+      .expect('code', 0)
+      .end();
+  });
+
+
+  before(() => {
+    app = mm.app({
+      baseDir: 'apps/connection-uri',
+    });
+    return app.ready();
+  });
+  // before(() => app.model.sync({ force: true }));
+
+  after(mm.restore);
+
+  describe('Base', () => {
+    it('sequelize init success', () => {
+      assert.ok(app.model);
+      assert.ok(app.model.User);
+    });
+  });
+});

--- a/test/fixtures/apps/connection-uri/app/controller/home.ts
+++ b/test/fixtures/apps/connection-uri/app/controller/home.ts
@@ -1,0 +1,10 @@
+import { Controller } from 'egg';
+
+export default class HomeController extends Controller {
+  async index() {
+    const { ctx } = this;
+    await ctx.model.Monkey.findUser();
+    await ctx.model.User.associate();
+    await ctx.model.User.test();
+  }
+}

--- a/test/fixtures/apps/connection-uri/app/model/monkey.ts
+++ b/test/fixtures/apps/connection-uri/app/model/monkey.ts
@@ -1,0 +1,24 @@
+'use strict';
+
+import { Application } from 'egg';
+
+export default function(app: Application) {
+  const { STRING, INTEGER, DATE } = app.Sequelize;
+  const Monkey = app.model.define('monkey', {
+    name: {
+      type: STRING,
+      allowNull: false,
+    },
+    user_id: INTEGER,
+    created_at: DATE,
+    updated_at: DATE,
+  }, {
+    tableName: 'the_monkeys',
+  });
+
+  return class extends Monkey {
+    static async findUser() {
+      return app.model.User.findOne({ where: { id: '123' } });
+    }
+  }
+}

--- a/test/fixtures/apps/connection-uri/app/model/user.ts
+++ b/test/fixtures/apps/connection-uri/app/model/user.ts
@@ -1,0 +1,25 @@
+'use strict';
+
+import { Application } from 'egg';
+import assert = require('assert');
+
+export default function(app: Application) {
+  const { STRING, INTEGER } = app.Sequelize;
+  const User = app.model.define('user', {
+    name: STRING(30),
+    age: INTEGER,
+  });
+
+  return class extends User {
+    static async associate() {
+      assert.ok(app.model.User);
+    }
+
+    static async test() {
+      assert(app.config);
+      assert(app.model.User === this);
+      const monkey = await app.model.Monkey.create({ name: 'The Monkey' });
+      assert(monkey.isNewRecord === false);
+    }
+  }
+}

--- a/test/fixtures/apps/connection-uri/app/router.ts
+++ b/test/fixtures/apps/connection-uri/app/router.ts
@@ -1,0 +1,7 @@
+import { Application } from 'egg';
+
+export default (app: Application) => {
+  const { controller } = app;
+
+  app.get('/', controller.home.index);
+}

--- a/test/fixtures/apps/connection-uri/config/config.default.ts
+++ b/test/fixtures/apps/connection-uri/config/config.default.ts
@@ -1,0 +1,13 @@
+import * as path from 'path';
+import { EggAppInfo, EggAppConfig, PowerPartial } from 'egg';
+
+export default (appInfo: EggAppInfo) => {
+  const config = {} as PowerPartial<EggAppConfig>;
+
+  config.keys = '123123';
+
+  config.sequelize = {
+  }
+
+  return config;
+}

--- a/test/fixtures/apps/connection-uri/config/config.local.ts
+++ b/test/fixtures/apps/connection-uri/config/config.local.ts
@@ -1,0 +1,15 @@
+import * as path from 'path';
+import { EggAppInfo, EggAppConfig, PowerPartial } from 'egg';
+
+export default (appInfo: EggAppInfo) => {
+  const config = {} as PowerPartial<EggAppConfig>;
+
+  config.keys = '123123';
+
+  config.sequelize = {
+    connectionUri: 'mysql://root:@127.0.0.1:3306/test4',
+    dialect: 'mysql'
+  }
+
+  return config;
+}

--- a/test/fixtures/apps/connection-uri/config/config.unittest.ts
+++ b/test/fixtures/apps/connection-uri/config/config.unittest.ts
@@ -1,0 +1,15 @@
+import * as path from 'path';
+import { EggAppInfo, EggAppConfig, PowerPartial } from 'egg';
+
+export default (appInfo: EggAppInfo) => {
+  const config = {} as PowerPartial<EggAppConfig>;
+
+  config.keys = '123123';
+
+  config.sequelize = {
+    connectionUri: 'mysql://root:@127.0.0.1:3306/test4',
+    dialect: 'mysql'
+  }
+
+  return config;
+}

--- a/test/fixtures/apps/connection-uri/package.json
+++ b/test/fixtures/apps/connection-uri/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "connection-uri"
+}

--- a/test/fixtures/apps/connection-uri/tsconfig.json
+++ b/test/fixtures/apps/connection-uri/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2017",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "egg-sequelize": ["../../../../"]
+    }
+  }
+}

--- a/test/fixtures/apps/connection-uri/typings/index.d.ts
+++ b/test/fixtures/apps/connection-uri/typings/index.d.ts
@@ -1,0 +1,16 @@
+import 'egg';
+import 'egg-sequelize';
+import HomeController from '../app/controller/home';
+import MonkeyModel from '../app/model/monkey';
+import UserModel from '../app/model/user';
+
+declare module 'egg' {
+  interface IController {
+    home: HomeController;
+  }
+
+  interface IModel {
+    Monkey: ReturnType<typeof MonkeyModel>;
+    User: ReturnType<typeof UserModel>;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
允许在配置里加入 mysql 连接字符串来配置，而不用分别配置 host, port, username, password, database 等等（很多数据库连接是通过 connection uri 给出的，直接复制粘贴更方便，也减少人肉解析和粘贴时带来出错的可能性）。