### PR TITLE
fix: external interface merging support to add `Sequelize` property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as sequelize from 'sequelize';
 
-interface EggSequelizeOptions extends sequelize.Options {
+export interface EggSequelizeOptions extends sequelize.Options {
   delegate?: string;
   baseDir?: string;
   exclude?: string;


### PR DESCRIPTION
external merge EggSequelizeOptions interface to add `Sequelize` property for custom sequelize, like:

```typescript
    export interface EggSequelizeOptions {
        Sequelize?: typeof Sequelize;
    }
```

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
