### PR TITLE
feat: add Sequelize to config's declaration and test it works with sequelize-typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ run
 test/fixtures/apps/model-app/run/
 test/fixtures/apps/ts/**/*.js
 test/fixtures/apps/connection-uri/**/*.js
+test/fixtures/apps/typescript/**/*.js
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ exports.sequelize = {
 };
 ```
 
+- In case your project is typescript and you are going to use `sequelize-typescript` instead of `sequelize`, then edit your own configurations in `conif/config.{env}.ts`
+
+
+```typescript
+exports.sequelize = {
+  Sequelize: require('sequelize-typescript'),
+  dialect: 'mysql', // support: mysql, mariadb, postgres, mssql
+  database: 'test',
+  host: 'localhost',
+  port: 3306,
+  username: 'root',
+  password: '',
+  // delegate: 'myModel', // load all models to `app[delegate]` and `ctx[delegate]`, default to `model`
+  // baseDir: 'my_model', // load all files in `app/${baseDir}` as models, default to `model`
+  // exclude: 'index.js', // ignore `app/${baseDir}/index.js` when load models, support glob and array
+  // more sequelize options
+};
+```
+
 You can also use the `connection uri` to configure the connection:
 
 ```js
@@ -126,6 +145,7 @@ Define a model first.
 
 > NOTE: `options.delegate` default to `model`, so `app.model` is an [Instance of Sequelize](http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor), so you can use methods like: `app.model.sync, app.model.query ...`
 
+- Define model in plain js fashion:
 ```js
 // app/model/user.js
 
@@ -158,6 +178,61 @@ module.exports = app => {
   return User;
 };
 
+```
+
+- Define model in typescript fashion:
+> Before you go this way, make sure your `tsconfig.json` contains the following:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strictPropertyInitialization": false
+  }
+}
+```
+
+```typescript
+// app/model/user.ts
+
+import {Column, Model, Table, DataType} from 'sequelize-typescript'
+
+@Table({
+  tableName: 'user',
+})
+class User extends Model<User> {
+  @Column(DataType.STRING)
+  login: string
+
+  @Column(DataType.STRING(30))
+  name: string
+
+  @Column(DataType.STRING(32))
+  password: string
+
+  @Column(DataType.INTEGER)
+  age: number
+
+  @Column(DataType.DATE)
+  last_sign_in_at: Date
+
+  @Column(DataType.DATE)
+  created_at: Date
+
+  @Column(DataType.DATE)
+  updated_at: Date
+
+  static async findByLogin(login: string) {
+    return await this.findOne({where:{login}})  
+  }
+
+  async logSignin() {
+    return await this.update({ last_sign_in_at: new Date() });
+  }
+}
+
+export default () => User
 ```
 
 Now you can use it in your controller:
@@ -301,7 +376,6 @@ module.exports = app => {
 };
 ```
 
-
 ```js
 // app/controller/post.js
 class PostController extends Controller {
@@ -359,6 +433,17 @@ Using [sequelize-cli](https://github.com/sequelize/cli) to help manage your data
 ## Questions & Suggestions
 
 Please open an issue [here](https://github.com/eggjs/egg/issues).
+
+## Contribution
+
+### Run test locally
+Testing needs connecting to databases, on TravisCI this is addressed by claiming `mysql` services. To run test locally, `docker` is recommended installed first, then
+
+```shell script
+sh test.sh
+``` 
+
+which will start a `mysql` container and create relevant databases.
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,11 +24,11 @@ interface EggSequelizeOptions extends sequelize.Options {
   connectionUri?: string;
 
   /**
-   * Customized sequelize instance
+   * support customizing sequelize class, default to `require('sequelize')`
    * @example
    * `Sequelize: require('sequelize-typescript').Sequelize`
    */
-  Sequelize?: any;
+  Sequelize?: typeof sequelize.Sequelize;
 }
 
 interface DataSources {

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,9 +19,16 @@ interface EggSequelizeOptions extends sequelize.Options {
   /**
    * A full database URI
    * @example
-   * `connectionUri:"mysql://localhost:3306/database"`
+   * `connectionUri: "mysql://localhost:3306/database"`
    */
   connectionUri?: string;
+
+  /**
+   * Customized sequelize instance
+   * @example
+   * `Sequelize: require('sequelize-typescript').Sequelize`
+   */
+  Sequelize?: any;
 }
 
 interface DataSources {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -102,7 +102,7 @@ module.exports = app => {
       caseStyle: 'upper',
       ignore: config.exclude,
       filter(model) {
-        if (!model || !model.sequelize) return false;
+        if (!model || (!model.sequelize && !model.findAll)) return false;
         models.push(model);
         return true;
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@types/sequelize": "^4.27.24",
     "mz-modules": "^2.1.0",
-    "sequelize": "^5.0.0"
+    "sequelize": "^5.0.0",
+    "sequelize-typescript": "^1.0.0"
   },
   "devDependencies": {
     "autod": "^3.0.1",
@@ -24,7 +25,8 @@
     "egg-mock": "^3.19.3",
     "eslint": "^5.3.0",
     "eslint-config-egg": "^7.0.0",
-    "mysql2": "^1.6.1"
+    "mysql2": "^1.6.1",
+    "reflect-metadata": "^0.1.13"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+container_name='local-mysql'
+
+if [ "$(docker inspect -f '{{.State.Running}}' $container_name)" = "true" ]; then
+  echo "$container_name is already running."
+else
+  docker kill $container_name || echo "$container_name is already killed"
+  docker rm $container_name || echo "$container_name not exist"
+  docker run --name $container_name -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -d -p 3306:3306 mysql:5.7
+
+  sleep 10
+fi
+
+# shellcheck disable=SC2016
+mysql -h 127.0.0.1 -u root -e 'CREATE DATABASE IF NOT EXISTS `test`;'
+mysql -h 127.0.0.1 -u root -e 'CREATE DATABASE IF NOT EXISTS `test1`;'
+mysql -h 127.0.0.1 -u root -e 'CREATE DATABASE IF NOT EXISTS `test2`;'
+mysql -h 127.0.0.1 -u root -e 'CREATE DATABASE IF NOT EXISTS `test3`;'
+mysql -h 127.0.0.1 -u root -e 'CREATE DATABASE IF NOT EXISTS `test4`;'
+# shellcheck disable=SC2016
+echo 'databases is there'
+
+npm run test-local
+
+#!/usr/bin/env bash
+
+#docker kill local-mysql || echo "local-mysql is already killed"

--- a/test/fixtures/apps/typescript/app/controller/home.ts
+++ b/test/fixtures/apps/typescript/app/controller/home.ts
@@ -1,0 +1,10 @@
+import { Controller } from 'egg';
+
+export default class HomeController extends Controller {
+  async index() {
+    const { ctx } = this;
+    await ctx.model.Monkey.findUser();
+    await ctx.model.User.associate();
+    await ctx.model.User.test();
+  }
+}

--- a/test/fixtures/apps/typescript/app/model/monkey.ts
+++ b/test/fixtures/apps/typescript/app/model/monkey.ts
@@ -1,0 +1,27 @@
+import {Column, DataType, Model, Table} from "sequelize-typescript";
+
+@Table({
+    tableName: 'the_monkeys'
+})
+class Monkey extends Model<Monkey> {
+    @Column({
+        type: DataType.STRING,
+        allowNull: false
+    })
+    name: string
+
+    @Column({type: DataType.INTEGER})
+    user_id: number
+
+    @Column(DataType.DATE)
+    created_at: Date
+
+    @Column(DataType.DATE)
+    updated_at: Date
+
+    static async findUser() {
+        return this.findOne({where: {id: '123'}})
+    }
+}
+
+export default () => Monkey

--- a/test/fixtures/apps/typescript/app/model/monkey.ts
+++ b/test/fixtures/apps/typescript/app/model/monkey.ts
@@ -1,4 +1,5 @@
-import {Column, DataType, Model, Table} from "sequelize-typescript";
+import {Column, DataType, Model, Table, Sequelize} from "sequelize-typescript";
+import {Application} from "egg";
 
 @Table({
     tableName: 'the_monkeys'
@@ -24,4 +25,8 @@ class Monkey extends Model<Monkey> {
     }
 }
 
-export default () => Monkey
+export default (_: Application, sequelize: Sequelize) => {
+    sequelize.addModels([Monkey])
+
+    return Monkey;
+}

--- a/test/fixtures/apps/typescript/app/model/user.ts
+++ b/test/fixtures/apps/typescript/app/model/user.ts
@@ -1,6 +1,6 @@
 import {Application} from 'egg';
 import assert = require('assert');
-import {Column, DataType, Model, Table} from "sequelize-typescript";
+import {Column, DataType, Model, Sequelize, Table} from "sequelize-typescript";
 
 @Table({tableName: 'user'})
 class User extends Model<User> {
@@ -11,8 +11,8 @@ class User extends Model<User> {
     age: number
 }
 
-export default function (app: Application) {
-    return class extends User {
+export default function (app: Application, sequelize: Sequelize) {
+    const UserModel = class extends User {
         static async associate() {
             assert.ok(app.model.User);
         }
@@ -21,7 +21,11 @@ export default function (app: Application) {
             assert(app.config);
             assert(app.model.User === this);
             const monkey = await app.model.Monkey.create({name: 'The Monkey'});
-            assert(monkey.isNewRecord === false);
+            assert(!monkey.isNewRecord);
         }
-    }
+    };
+
+    sequelize.addModels([UserModel])
+
+    return UserModel
 }

--- a/test/fixtures/apps/typescript/app/model/user.ts
+++ b/test/fixtures/apps/typescript/app/model/user.ts
@@ -1,0 +1,27 @@
+import {Application} from 'egg';
+import assert = require('assert');
+import {Column, DataType, Model, Table} from "sequelize-typescript";
+
+@Table({tableName: 'user'})
+class User extends Model<User> {
+    @Column(DataType.STRING(3))
+    name: string
+
+    @Column(DataType.INTEGER)
+    age: number
+}
+
+export default function (app: Application) {
+    return class extends User {
+        static async associate() {
+            assert.ok(app.model.User);
+        }
+
+        static async test() {
+            assert(app.config);
+            assert(app.model.User === this);
+            const monkey = await app.model.Monkey.create({name: 'The Monkey'});
+            assert(monkey.isNewRecord === false);
+        }
+    }
+}

--- a/test/fixtures/apps/typescript/app/router.ts
+++ b/test/fixtures/apps/typescript/app/router.ts
@@ -1,0 +1,7 @@
+import { Application } from 'egg';
+
+export default (app: Application) => {
+  const { controller } = app;
+
+  app.get('/', controller.home.index);
+}

--- a/test/fixtures/apps/typescript/config/config.default.ts
+++ b/test/fixtures/apps/typescript/config/config.default.ts
@@ -1,0 +1,41 @@
+import * as path from 'path';
+import {EggAppInfo, EggAppConfig, PowerPartial} from 'egg';
+
+export default (appInfo: EggAppInfo) => {
+    const config = {} as PowerPartial<EggAppConfig>;
+
+    config.keys = '123123';
+
+    config.sequelize = {
+        Sequelize: require('sequelize-typescript').Sequelize,
+        datasources: [
+            {
+                delegate: 'model',
+                baseDir: 'model',
+                database: 'test',
+                dialect: 'mysql',
+            },
+            {
+                delegate: 'sequelize',
+                baseDir: 'sequelize',
+                database: 'test1',
+                dialect: 'mysql',
+                exclude: 'Person.js',
+            },
+            {
+                delegate: 'subproperty.a',
+                baseDir: 'subproperty/a',
+                database: 'test2',
+                dialect: 'mysql',
+            },
+            {
+                delegate: 'subproperty.b',
+                baseDir: 'subproperty/b',
+                database: 'test3',
+                dialect: 'mysql',
+            },
+        ]
+    }
+
+    return config;
+}

--- a/test/fixtures/apps/typescript/package.json
+++ b/test/fixtures/apps/typescript/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "typescript"
+}

--- a/test/fixtures/apps/typescript/tsconfig.json
+++ b/test/fixtures/apps/typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2017",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strictPropertyInitialization": false,
+    "paths": {
+      "egg-sequelize": [
+        "../../../../"
+      ]
+    }
+  }
+}

--- a/test/fixtures/apps/typescript/typings/index.d.ts
+++ b/test/fixtures/apps/typescript/typings/index.d.ts
@@ -1,0 +1,16 @@
+import 'egg';
+import 'egg-sequelize';
+import HomeController from '../app/controller/home';
+import MonkeyModel from '../app/model/monkey';
+import UserModel from '../app/model/user';
+
+declare module 'egg' {
+  interface IController {
+    home: HomeController;
+  }
+
+  interface IModel {
+    Monkey: ReturnType<typeof MonkeyModel>;
+    User: ReturnType<typeof UserModel>;
+  }
+}

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -47,6 +47,8 @@ describe('typescript form 2', () => {
     assert.ok(ctx.model);
     assert.ok(ctx.model.User);
     assert.ok(ctx.model.Monkey);
+    const res = await app.model.User.destroy({ truncate: true, force: true });
+    assert.ok(typeof res === 'number');
     assert.ok(ctx.model !== app.model);
   });
 });

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -2,6 +2,8 @@
 
 const coffee = require('coffee');
 const path = require('path');
+const mm = require('egg-mock');
+const assert = require('assert');
 
 describe('typescript', () => {
   it('should compile ts without error', () => {
@@ -12,5 +14,39 @@ describe('typescript', () => {
       .debug()
       .expect('code', 0)
       .end();
+  });
+});
+
+
+describe('typescript form 2', () => {
+
+  let app;
+
+  before(async () => {
+    await coffee.fork(
+      require.resolve('typescript/bin/tsc'),
+      [ '-p', path.resolve(__dirname, './fixtures/apps/typescript/tsconfig.json') ]
+    )
+      .debug()
+      .expect('code', 0)
+      .end();
+
+    app = mm.app({
+      baseDir: 'apps/typescript',
+    });
+
+    return app.ready();
+  });
+
+  before(() => app.model.sync({ force: true }));
+
+  after(mm.restore);
+
+  it('should have models', async () => {
+    const ctx = app.mockContext();
+    assert.ok(ctx.model);
+    assert.ok(ctx.model.User);
+    assert.ok(ctx.model.Monkey);
+    assert.ok(ctx.model !== app.model);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
- `index.d.ts` 增加 `Sequelize` 字段以反映真实的设置，以及支持 `TypeScript` 里定制这个字段。
- `README.md` 增加如何在 `TypeScript` 版 egg 项目里使用 `sequelize-typescript` 的说明。
- `test` 目录下增加在 `TypeScript` 版 egg 项目里使用 `sequelize-typescript` 的测试用例。
- `README.md` 增加如何在本地运行此项目的单元测试的说明。
-  增加`test.sh` 以方便本地单元测试。